### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,16 +5,16 @@ jobs:
   omnilint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - uses: docker://lpenz/omnilint:0.4
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - uses: docker://lpenz/ghaction-cmake:0.19
         with:
           preset: coverage
-      - uses: coverallsapp/github-action@master
+      - uses: coverallsapp/github-action@1.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: lcov.info
@@ -33,23 +33,23 @@ jobs:
             - valgrind
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - uses: docker://lpenz/ghaction-cmake:0.19
         with:
           preset: ${{ matrix.preset }}
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - uses: DoozyX/clang-format-lint-action@v0.5
   cachix:
     needs: [ omnilint, clang-format, tests, coverage ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
       - id: version
         uses: docker://lpenz/ghaction-version-gen:0.8.0
-      - uses: cachix/install-nix-action@v16
+      - uses: cachix/install-nix-action@v17
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: cachix/cachix-action@v10
@@ -87,10 +87,10 @@ jobs:
             distro: raspbian
             version: bullseye
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
-      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-qemu-action@v2.0.0
       - uses: docker://lpenz/ghaction-cmake:0.19-386
         if: matrix.variant.image == '386'
         with:

--- a/.github/workflows/ghaction-updater.yml
+++ b/.github/workflows/ghaction-updater.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.0.2
         with:
           token: ${{ secrets.GHACTION_UPDATER_TOKEN }}
       - uses: saadmk11/github-actions-version-updater@v0.5.6


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release [v2.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v2.0.0) on 2022-05-05T16:25:31Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
* **[coverallsapp/github-action](https://github.com/coverallsapp/github-action)** published a new release [1.1.3](https://github.com/coverallsapp/github-action/releases/tag/1.1.3) on 2021-07-06T19:34:34Z
* **[cachix/install-nix-action](https://github.com/cachix/install-nix-action)** published a new release [v17](https://github.com/cachix/install-nix-action/releases/tag/v17) on 2022-04-07T09:47:46Z
